### PR TITLE
fix: Load more data when there is not scroll on the page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -24,36 +24,46 @@ function App() {
   const [idxdub, setIdxdub] = useState(1);
   const renderAfterCalled = useRef(false);
   const [searchResult, setSearchResult] = useState(null);
+  const [loading, setLoading] = useState(true);
 
   // Fetch Functions
   const getAnime = async (id = 1) => {
     try {
+      setLoading(true);
       const Data = await axios.get(
         `https://gogoanime.herokuapp.com/recent-release?page=${id}`
       );
       setRecent((recent) => [...recent, ...Data.data]);
+      setLoading(false);
     } catch (err) {
       console.log("err");
+      setLoading(false);
     }
   };
   const getPropular = async (id = 1) => {
     try {
+      setLoading(true);
       const propu = await axios.get(
         `https://gogoanime.herokuapp.com/popular?page=${id}`
       );
       setPopular((popular) => [...popular, ...propu.data]);
+      setLoading(false);
     } catch (err) {
       console.log("err");
+      setLoading(false);
     }
   };
   const getDub = async (id = 1) => {
     try {
+      setLoading(true);
       const Data = await axios.get(
         `https://gogoanime.herokuapp.com/recent-release?type=2&page=${id}`
       );
       setDub((dub) => [...dub, ...Data.data]);
+      setLoading(false);
     } catch (err) {
       console.log("err");
+      setLoading(false);
     }
   };
 
@@ -118,6 +128,7 @@ function App() {
               searchResult={searchResult}
               handelClick={handelClick}
               loadMoreRecent={loadMoreRecent}
+              loading={loading}
             />
           }
         />
@@ -129,6 +140,7 @@ function App() {
               popular={popular}
               handelClick={handelClick}
               loadMorePopular={loadMorePopular}
+              loading={loading}
             />
           }
         />
@@ -141,6 +153,7 @@ function App() {
               searchResult={searchResult}
               handelClick={handelClick}
               loadMoreDub={loadMoreDub}
+              loading={loading}
             />
           }
         />

--- a/src/Pages/DubAnime.js
+++ b/src/Pages/DubAnime.js
@@ -1,16 +1,25 @@
-import React from "react";
+import React, { useRef } from "react";
 import { Helmet } from "react-helmet";
 import InfiniteScroll from "react-infinite-scroll-component";
 import Card from "../Components/Card";
 import spinner from "../img/Spinner.gif";
 
+import { useFetchInitialData } from "../utils/hooks";
+
 const DubAnime = (props, ref) => {
+  const clientRef = useRef(null);
+
   const handelClick = () => {
     props.handelClick();
   };
   const loadMore = () => {
     props.loadMoreDub();
   };
+
+  const { loading, recent, loadMoreDub } = props;
+
+  useFetchInitialData(loading, recent, loadMoreDub, clientRef, window)
+
   return (
     <>
       <Helmet>
@@ -38,7 +47,7 @@ const DubAnime = (props, ref) => {
         </div>
       ) : (
         <div className="container__total">
-          <div className="container__main row">
+          <div className="container__main row" ref={clientRef}>
             <h1
               style={{
                 marginTop: "20px",
@@ -51,7 +60,7 @@ const DubAnime = (props, ref) => {
             </h1>
 
             {props.recent.map((rec) => (
-              <Card rec={rec} key={rec.animeId} handelClick={handelClick} />
+              <Card rec={rec} key={rec.episodeId} handelClick={handelClick} />
             ))}
           </div>
           <InfiniteScroll

--- a/src/Pages/Popular.js
+++ b/src/Pages/Popular.js
@@ -1,15 +1,25 @@
-import React from "react";
+import React, { useRef } from "react";
 import { Helmet } from "react-helmet";
 import InfiniteScroll from "react-infinite-scroll-component";
 import spinner from "../img/Spinner.gif";
 import Card from "../Components/Card";
+
+import { useFetchInitialData } from "../utils/hooks";
+
 const Popular = (props) => {
+  const ref = useRef(null);
+
   const handelClick = () => {
     props.handelClick();
   };
   const loadMore = () => {
     props.loadMorePopular();
   };
+
+  const { loading, popular, loadMorePopular } = props;
+
+  useFetchInitialData(loading, popular, loadMorePopular, ref, window)
+
   return (
     <>
       <Helmet>
@@ -37,7 +47,7 @@ const Popular = (props) => {
         </div>
       ) : (
         <div className="container__total">
-          <div className="container__main row Popular">
+          <div className="container__main row Popular" ref={ref}>
             <h1
               style={{
                 marginTop: "20px",

--- a/src/Pages/RecentAnime.js
+++ b/src/Pages/RecentAnime.js
@@ -1,12 +1,15 @@
-import React from "react";
+import React, { useState, useRef } from "react";
 import { Helmet } from "react-helmet";
 import InfiniteScroll from "react-infinite-scroll-component";
 import spinner from "../img/Spinner.gif";
 import Card from "../Components/Card";
 import Lastwatch from "../Components/Lastwatch"
-import { useState } from "react";
+
+import { useFetchInitialData } from "../utils/hooks";
 
 const RecentAnime = (props) => {
+  const ref = useRef(null);
+
   const handelClick = () => {
     props.handelClick();
   };
@@ -33,6 +36,11 @@ const RecentAnime = (props) => {
     if (fetchLastWatch)
       setLastwatch(fetchLastWatch);
   }, []);
+
+  const { loading, recent, loadMoreRecent } = props;
+
+  useFetchInitialData(loading, recent, loadMoreRecent, ref, window)
+
   return (
     <>
       <Helmet>
@@ -61,7 +69,7 @@ const RecentAnime = (props) => {
       ) : (
         <>
           <div className="container__total">
-            <div className="container__main row">
+            <div className="container__main row" ref={ref}>
               <h1
                 style={{
                   marginTop: "20px",
@@ -74,7 +82,7 @@ const RecentAnime = (props) => {
               </h1>
               {props.recent &&
                 props.recent.map((rec) => (
-                  <Card rec={rec} key={rec.animeId} handelClick={handelClick} />
+                  <Card rec={rec} key={rec.episodeId} handelClick={handelClick} />
                 ))}
             </div>
             <InfiniteScroll

--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -1,0 +1,10 @@
+import { useEffect } from "react";
+
+export const useFetchInitialData = (loading, data, fetchData, clientRef, container) => {
+    
+    useEffect(() => {
+        if (clientRef.current && container && !loading && ((clientRef.current.clientHeight + 150) < container.innerHeight)) {
+            fetchData();  
+        }
+    }, [loading, data, clientRef, fetchData, container]);
+}


### PR DESCRIPTION
Now the data is getting loaded even when there is no scroll on the page, i.e., for large resolutions.

Fixes #1 

https://user-images.githubusercontent.com/41188167/197613497-9c53e391-b93d-43b7-9a95-50a543abacb5.mov

